### PR TITLE
Add teacher admin mode for activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,23 +1,49 @@
 """
 High School Management System API
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
+A super simple FastAPI application that allows students to view activities and
+teachers to manage extracurricular registrations at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+import json
 import os
 from pathlib import Path
+import secrets
 
 app = FastAPI(title="Mergington High School API",
-              description="API for viewing and signing up for extracurricular activities")
+              description="API for viewing and managing extracurricular activities")
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+SESSION_COOKIE_NAME = "teacher_session"
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def load_teacher_credentials() -> dict[str, str]:
+    teachers_path = current_dir / "teachers.json"
+
+    with teachers_path.open(encoding="utf-8") as credentials_file:
+        teachers = json.load(credentials_file)["teachers"]
+
+    return {
+        teacher["username"]: teacher["password"]
+        for teacher in teachers
+    }
+
+
+teacher_credentials = load_teacher_credentials()
+active_sessions: dict[str, str] = {}
 
 # In-memory activity database
 activities = {
@@ -78,6 +104,18 @@ activities = {
 }
 
 
+def require_teacher(request: Request) -> str:
+    session_token = request.cookies.get(SESSION_COOKIE_NAME)
+
+    if not session_token or session_token not in active_sessions:
+        raise HTTPException(
+            status_code=401,
+            detail="Teacher login required"
+        )
+
+    return active_sessions[session_token]
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -88,15 +126,65 @@ def get_activities():
     return activities
 
 
+@app.get("/auth/status")
+def get_auth_status(request: Request):
+    session_token = request.cookies.get(SESSION_COOKIE_NAME)
+    username = active_sessions.get(session_token)
+
+    return {
+        "logged_in": bool(username),
+        "username": username
+    }
+
+
+@app.post("/auth/login")
+def login_teacher(credentials: LoginRequest, response: Response):
+    expected_password = teacher_credentials.get(credentials.username)
+
+    if expected_password != credentials.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    session_token = secrets.token_urlsafe(32)
+    active_sessions[session_token] = credentials.username
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=session_token,
+        httponly=True,
+        samesite="lax"
+    )
+
+    return {
+        "message": f"Logged in as {credentials.username}",
+        "username": credentials.username
+    }
+
+
+@app.post("/auth/logout")
+def logout_teacher(request: Request, response: Response):
+    session_token = request.cookies.get(SESSION_COOKIE_NAME)
+
+    if session_token:
+        active_sessions.pop(session_token, None)
+
+    response.delete_cookie(SESSION_COOKIE_NAME)
+    return {"message": "Logged out"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, request: Request):
     """Sign up a student for an activity"""
+    require_teacher(request)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate capacity
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(status_code=400, detail="Activity is full")
 
     # Validate student is not already signed up
     if email in activity["participants"]:
@@ -111,8 +199,10 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, request: Request):
     """Unregister a student from an activity"""
+    require_teacher(request)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,60 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const accountButton = document.getElementById("account-button");
+  const authPanel = document.getElementById("auth-panel");
+  const closeAuthPanelButton = document.getElementById("close-auth-panel");
+  const loginForm = document.getElementById("login-form");
+  const logoutButton = document.getElementById("logout-button");
+  const authStatusText = document.getElementById("auth-status-text");
+  const signupHelperText = document.getElementById("signup-helper-text");
+
+  let authState = {
+    loggedIn: false,
+    username: null,
+  };
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateAuthUI() {
+    const isLoggedIn = authState.loggedIn;
+
+    signupForm.classList.toggle("hidden", !isLoggedIn);
+    signupHelperText.textContent = isLoggedIn
+      ? `Logged in as ${authState.username}. You can register or unregister students.`
+      : "Teacher login is required to register or unregister students.";
+
+    authStatusText.textContent = isLoggedIn
+      ? `Logged in as ${authState.username}.`
+      : "Log in to manage student registrations.";
+
+    loginForm.classList.toggle("hidden", isLoggedIn);
+    logoutButton.classList.toggle("hidden", !isLoggedIn);
+    accountButton.classList.toggle("logged-in", isLoggedIn);
+    accountButton.title = isLoggedIn
+      ? `Logged in as ${authState.username}`
+      : "Teacher login";
+  }
+
+  async function fetchAuthStatus() {
+    const response = await fetch("/auth/status");
+    const result = await response.json();
+
+    authState = {
+      loggedIn: result.logged_in,
+      username: result.username,
+    };
+
+    updateAuthUI();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +66,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +86,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${authState.loggedIn ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>` : ""}</li>`
                   )
                   .join("")}
               </ul>
@@ -69,6 +125,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!authState.loggedIn) {
+      showMessage("Teacher login required", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -86,33 +147,92 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
+
+        if (response.status === 401) {
+          await fetchAuthStatus();
+        }
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
 
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed", "error");
+        return;
+      }
+
+      loginForm.reset();
+      await fetchAuthStatus();
+      await fetchActivities();
+      showMessage(result.message, "success");
+      authPanel.classList.add("hidden");
+    } catch (error) {
+      showMessage("Failed to log in. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  logoutButton.addEventListener("click", async () => {
+    try {
+      const response = await fetch("/auth/logout", { method: "POST" });
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Logout failed", "error");
+        return;
+      }
+
+      await fetchAuthStatus();
+      await fetchActivities();
+      showMessage(result.message, "success");
+      authPanel.classList.add("hidden");
+    } catch (error) {
+      showMessage("Failed to log out. Please try again.", "error");
+      console.error("Error logging out:", error);
+    }
+  });
+
+  accountButton.addEventListener("click", () => {
+    authPanel.classList.toggle("hidden");
+  });
+
+  closeAuthPanelButton.addEventListener("click", () => {
+    authPanel.classList.add("hidden");
+  });
+
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!authState.loggedIn) {
+      showMessage("Teacher login required", "error");
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -130,31 +250,24 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
+
+        if (response.status === 401) {
+          await fetchAuthStatus();
+        }
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
   // Initialize app
-  fetchActivities();
+  fetchAuthStatus().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,9 +8,38 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="header-bar">
+        <div>
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+        <button id="account-button" class="account-button" type="button" aria-label="Teacher account">
+          <span aria-hidden="true">👤</span>
+        </button>
+      </div>
     </header>
+
+    <div id="auth-panel" class="auth-panel hidden">
+      <div class="auth-panel-card">
+        <div class="auth-panel-header">
+          <h3>Teacher Access</h3>
+          <button id="close-auth-panel" class="panel-close" type="button" aria-label="Close teacher access panel">×</button>
+        </div>
+        <p id="auth-status-text" class="auth-status-text">Log in to manage student registrations.</p>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required autocomplete="username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required autocomplete="current-password" />
+          </div>
+          <button id="login-button" type="submit">Log In</button>
+        </form>
+        <button id="logout-button" class="hidden" type="button">Log Out</button>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">
@@ -22,7 +51,10 @@
       </section>
 
       <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+        <h3>Register a Student</h3>
+        <p id="signup-helper-text" class="signup-helper-text">
+          Teacher login is required to register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,7 +16,6 @@ body {
 }
 
 header {
-  text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
@@ -24,8 +23,81 @@ header {
   border-radius: 5px;
 }
 
+.header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 20px;
+}
+
+.header-bar > div {
+  flex: 1;
+  text-align: center;
+}
+
 header h1 {
   margin-bottom: 10px;
+}
+
+.account-button {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.account-button.logged-in {
+  background-color: #2e7d32;
+  border-color: #a5d6a7;
+}
+
+.auth-panel {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: -20px;
+  margin-bottom: 20px;
+}
+
+.auth-panel-card {
+  width: 100%;
+  max-width: 360px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+  padding: 18px;
+}
+
+.auth-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.panel-close {
+  background: none;
+  color: #1a237e;
+  font-size: 24px;
+  line-height: 1;
+  padding: 0;
+}
+
+.panel-close:hover {
+  background: none;
+  color: #3949ab;
+}
+
+.auth-status-text,
+.signup-helper-text {
+  margin-bottom: 15px;
+  color: #555;
 }
 
 main {
@@ -125,6 +197,10 @@ section h3 {
   background-color: #ffebee;
 }
 
+#logout-button {
+  width: 100%;
+}
+
 .participants-section p {
   color: #777;
   font-style: italic;
@@ -190,6 +266,24 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+@media (max-width: 767px) {
+  .header-bar {
+    padding: 0 16px;
+  }
+
+  .header-bar > div {
+    text-align: left;
+  }
+
+  .auth-panel {
+    justify-content: stretch;
+  }
+
+  .auth-panel-card {
+    max-width: none;
+  }
 }
 
 footer {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "ms.fraser",
+      "password": "falcons2026"
+    },
+    {
+      "username": "mr.lee",
+      "password": "stemclub"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Add a teacher-only admin mode for managing extracurricular registrations.

## What changed
- add teacher login, logout, and auth status endpoints backed by a checked-in JSON credential file
- require a logged-in teacher for student registration and unregistration actions
- add a top-right account control and teacher login panel in the frontend
- keep participant lists visible to students while hiding mutation controls unless a teacher is logged in
- fix repeated activity refreshes so the activity dropdown does not duplicate options

## Validation
- verified unauthenticated registration returns `401`
- verified teacher login succeeds and authenticated registration/unregistration succeeds
- verified logout clears access and post-logout mutations return `401`

Closes #5